### PR TITLE
Public access to the full text received so far

### DIFF
--- a/features/full-text.feature
+++ b/features/full-text.feature
@@ -1,0 +1,14 @@
+Feature: accessing the full output received so far
+
+  As a developer using text-stream-seach to search through a stream
+  I want to be able to get the full text content received so far
+  So that I can inspect it manually if I want to.
+
+  - call ".fullText()" on a search instance to get the complete text received so far
+
+
+  Scenario: the instance has received some text already
+    Given a TextStreamSearch instance
+    And the stream emits "hello world"
+    When calling 'fullText()' on that instance
+    Then it returns "hello world"

--- a/features/steps/steps.ls
+++ b/features/steps/steps.ls
@@ -19,9 +19,17 @@ module.exports = ->
 
 
 
+  @When /^calling 'fullText\(\)' on that instance$/, ->
+    @result = @instance.full-text!
+
+
   @When /^the stream emits "([^"]*)"$/, (text) ->
     @stream.append text
 
+
+
+  @Then /^it returns "([^"]*)"$/, (expected-text) ->
+    expect(@result).to.equal expected-text
 
 
   @Then /^the callback for "([^"]*)" fires(?: only once)?$/, (search-term) ->

--- a/src/text-stream-search.ls
+++ b/src/text-stream-search.ls
@@ -16,6 +16,11 @@ class TextStreamSearch
     @_output = new TextStreamAccumulator stream
 
 
+  # Returns the full text received from the stream so far
+  full-text: ->
+    @_output.to-string!
+
+
   # Calls the given handler when the given text shows up in the output
   wait: (text, handler) ->
     @_searches.push {text, handler}


### PR DESCRIPTION
@alexdavid 

This library allows to search a text stream for a given string.
This change here provides public access to the full text received from a stream so far.
This is used in testing.