### PR TITLE
Reset called counter

### DIFF
--- a/features/steps/steps.ls
+++ b/features/steps/steps.ls
@@ -47,6 +47,7 @@ module.exports = ->
   @Then /^the callback for "([^"]*)" fires(?: only once)?$/, (search-term, done) ->
     set-immediate ~>
       expect(@called).to.equal 1
+      @called = 0
       done!
 
 


### PR DESCRIPTION
Some test scenarios require two callbacks being fired. The `@called` object should be reset after it is checked against `expect(@called).to.equal 1`, so that the next time it is incremented it will be incremented to 1. This error was not showing up previously because the callback for `set-immediate` was never being called - that issue is being addressed in this PR: https://github.com/Originate/node-text-stream-search/pull/6

@kevgo 