### PR TITLE
add timeout

### DIFF
--- a/features/steps/steps.ls
+++ b/features/steps/steps.ls
@@ -60,7 +60,7 @@ module.exports = ->
   @Then /^the callback for "([^"]*)" fires(?: only once)?$/, (search-term, done) ->
     wait 1, ~>
       expect(@calls[search-term]).to.equal 1
-      expect(@err).to.equal undefined
+      expect(@err).to.be.undefined
       done!
 
 
@@ -73,7 +73,7 @@ module.exports = ->
   @Then /^the callback for "([^"]*)" does not fire again$/ (search-term, done) ->
     wait 1, ~>
       expect(@calls[search-term]).to.equal 1
-      expect(@err).to.equal undefined
+      expect(@err).to.be.undefined
       done!
 
 
@@ -84,8 +84,8 @@ module.exports = ->
       done!
 
 
-  @Then /^after (\d+) milliseconds the callback for "([^"]*)" has not fired again$/ (delay, search-term, done) ->
+  @Then /^within (\d+) milliseconds the callback for "([^"]*)" has not fired again$/ (delay, search-term, done) ->
     wait parseInt(delay), ~>
       expect(@calls[search-term]).to.equal 1
-      expect(@err).to.equal undefined
+      expect(@err).to.be.undefined
       done!

--- a/features/steps/steps.ls
+++ b/features/steps/steps.ls
@@ -15,8 +15,14 @@ module.exports = ->
 
   @Given /^I tell it to wait for "([^"]*)"$/, (search-term) ->
     (@calls or= {})[search-term] or= 0
-    @handler = ~> @calls[search-term] += 1
+    @handler = (@err) ~> @calls[search-term] += 1
     @instance.wait search-term, @handler
+
+
+  @Given /^I tell it to wait for "([^"]*)" with a timeout of (\d+) milliseconds$/, (search-term, timeout) ->
+    (@calls or= {})[search-term] or= 0
+    @handler = (@err) ~> @calls[search-term] += 1
+    @instance.wait search-term, @handler, parseInt(timeout)
 
 
   @Given /^a TextStreamSearch instance with accumulated text$/ ->
@@ -27,7 +33,7 @@ module.exports = ->
 
   @When /^I tell it to wait for the regular expression "([^"]*)"$/ (search-term) ->
     (@calls or= {})[search-term] or= 0
-    @handler = ~> @calls[search-term] += 1
+    @handler = (@err) ~> @calls[search-term] += 1
     @instance.wait new RegExp(search-term), @handler
 
 
@@ -54,6 +60,7 @@ module.exports = ->
   @Then /^the callback for "([^"]*)" fires(?: only once)?$/, (search-term, done) ->
     wait 1, ~>
       expect(@calls[search-term]).to.equal 1
+      expect(@err).to.equal undefined
       done!
 
 
@@ -66,4 +73,19 @@ module.exports = ->
   @Then /^the callback for "([^"]*)" does not fire again$/ (search-term, done) ->
     wait 1, ~>
       expect(@calls[search-term]).to.equal 1
+      expect(@err).to.equal undefined
+      done!
+
+
+  @Then /^within (\d+) milliseconds the callback for "([^"]*)" fires with the error:$/ (delay, search-term, error-message, done) ->
+    wait parseInt(delay), ~>
+      expect(@calls[search-term]).to.equal 1
+      expect(@err.message).to.eql error-message
+      done!
+
+
+  @Then /^after (\d+) milliseconds the callback for "([^"]*)" has not fired again$/ (delay, search-term, done) ->
+    wait parseInt(delay), ~>
+      expect(@calls[search-term]).to.equal 1
+      expect(@err).to.equal undefined
       done!

--- a/features/wait.feature
+++ b/features/wait.feature
@@ -22,6 +22,13 @@ Feature: Recognizing text in streams
     Then the callback for "hello" fires
 
 
+  Scenario: the text stream emits the expected string in one piece
+    Given I tell it to wait for "hello" with a timeout of 1000 milliseconds
+    When the stream emits "So I said hello to her"
+    Then the callback for "hello" fires
+    And after 1500 milliseconds the callback for "hello" has not fired again
+
+
   Scenario: the text stream emits the expected string in several pieces
     Given I tell it to wait for "hello"
     When the stream emits "So I said hel"
@@ -46,6 +53,15 @@ Feature: Recognizing text in streams
     Given I tell it to wait for "hello"
     When the stream emits "So I said hi to her"
     Then the callback for "hello" does not fire
+
+
+  Scenario: The expected text stream never contains the search term (with timeout)
+    Given I tell it to wait for "hello" with a timeout of 1000 milliseconds
+    When the stream emits "So I said hi to her"
+    Then within 1500 milliseconds the callback for "hello" fires with the error:
+      """
+      Expected 'So I said hi to her' to include string 'hello'
+      """
 
 
   Scenario: Multiple sequential searches

--- a/features/wait.feature
+++ b/features/wait.feature
@@ -26,7 +26,7 @@ Feature: Recognizing text in streams
     Given I tell it to wait for "hello" with a timeout of 1000 milliseconds
     When the stream emits "So I said hello to her"
     Then the callback for "hello" fires
-    And after 1500 milliseconds the callback for "hello" has not fired again
+    And within 1500 milliseconds the callback for "hello" has not fired again
 
 
   Scenario: the text stream emits the expected string in several pieces

--- a/src/base-search.ls
+++ b/src/base-search.ls
@@ -1,0 +1,37 @@
+debug = require('debug')('text-stream-search')
+
+
+# Calls the given handler exactly one time
+# when text matches the given string
+class BaseSearch
+
+  ({@accumulator, @handler, timeout}) ->
+    @called = no
+    if timeout
+      setTimeout @_on-timeout, timeout
+
+
+  # Checks for matches
+  #
+  # disables after the first match,
+  # subsequent calls are ignored
+  check: (text) ->
+    | @called        =>  return
+    | @matches text  =>  @_found-match text
+
+
+  # called when a match is found
+  _found-match: (text) ->
+    debug "found match for #{@get-display-name!}"
+    @called = yes
+    process.next-tick @handler
+
+
+  # called after a given timeout
+  _on-timeout: ~>
+    | @called => return
+    process.next-tick ~>
+      @handler new Error("Expected '#{@accumulator.to-string!}' to include #{@get-display-name!}" )
+
+
+module.exports = BaseSearch

--- a/src/regex-search.ls
+++ b/src/regex-search.ls
@@ -1,34 +1,24 @@
-debug = require('debug')('text-stream-search')
+require! {
+  './base-search' : BaseSearch
+}
 
 
 # Calls the given handler exactly one time
 # when text matches the given regex
-class RegexSearch
+class RegexSearch extends BaseSearch
 
-  (@search-regexp, @handler) ->
-    @called = no
+  ({query: @search-regexp}) ->
+    super ...
 
 
-  # Checks for matches in the given text
-  #
-  # disables after the first match,
-  # subsequent calls are ignored
-  check: (text) ->
-    | @called        =>  return
-    | @matches text  =>  @_found-match text
+  # Returns the display name for debug / error messages
+  get-display-name: ->
+    "regex '#{@search-regexp}'"
 
 
   # Returns whether the given text contains the search text this search is looking for
   matches: (text) ->
     @search-regexp.test text
-
-
-  # called when a match is found
-  _found-match: (text) ->
-    debug "found match for regex '#{@search-regexp}'"
-    @called = yes
-    process.next-tick @handler
-
 
 
 module.exports = RegexSearch

--- a/src/string-search.ls
+++ b/src/string-search.ls
@@ -1,34 +1,24 @@
-debug = require('debug')('text-stream-search')
+require! {
+  './base-search' : BaseSearch
+}
 
 
 # Calls the given handler exactly one time
 # when text matches the given string
-class StringSearch
+class StringSearch extends BaseSearch
 
-  (@search-text, @handler) ->
-    @called = no
+  ({query: @search-text}) ->
+    super ...
 
 
-  # Checks for matches in the given text
-  #
-  # disables after the first match,
-  # subsequent calls are ignored
-  check: (text) ->
-    | @called        =>  return
-    | @matches text  =>  @_found-match text
+  # Returns the display name for debug / error messages
+  get-display-name: ->
+    "string '#{@search-text}'"
 
 
   # Returns whether the given text contains the search text this search is looking for
   matches: (text) ->
     text.includes @search-text
-
-
-  # called when a match is found
-  _found-match: (text) ->
-    debug "found match for string '#{@search-text}'"
-    @called = yes
-    process.next-tick @handler
-
 
 
 module.exports = StringSearch

--- a/src/text-stream-search.ls
+++ b/src/text-stream-search.ls
@@ -27,17 +27,17 @@ class TextStreamSearch
 
 
   # Calls the given handler when the given text shows up in the output
-  wait: (text, handler) ->
-    debug "adding search for: #{text}"
-    @_searches.push @_create-search-instance text, handler
+  wait: (query, handler, timeout) ->
+    debug "adding search for: #{query}"
+    @_searches.push @_create-search-instance query, handler, timeout
     @_check-searches!
 
 
-  _create-search-instance: (text, handler) ->
-    switch (text-type = typeof! text)
-      | 'String'  =>  new StringSearch text, handler
-      | 'RegExp'  =>  new RegexSearch text, handler
-      | _         =>  throw new Error "unknown data type to wait for: #{text-type}"
+  _create-search-instance: (query, handler, timeout) ->
+    switch (query-type = typeof! query)
+      | 'String'  =>  new StringSearch {accumulator: @_accumulator, handler, query, timeout}
+      | 'RegExp'  =>  new RegexSearch {accumulator: @_accumulator, handler, query, timeout}
+      | _         =>  throw new Error "unknown data type to wait for: #{query-type}"
 
 
   # Called when new text arrives


### PR DESCRIPTION
Add the timeout options so when using this in cucumber use can get meaningful error messages  instead of a step timeout error. This is an alternative to always using debug mode or having to turn it on after a test fails